### PR TITLE
change to rule delete from DELETE to POST with parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ If you want to add `rules <http://support.gnip.com/customer/portal/articles/4777
 
     # Synchronously add rules
     try:
-        rules.add_rule('(Hello OR World OR "this is a test") AND lang:en', tag="MyRule")
+        rules.add_rule('(Hello OR World OR "this is a test") lang:en', tag="MyRule")
         rules.add_rule('Rule without a tag')
     except RuleAddFailedException:
         pass

--- a/gnippy/rules.py
+++ b/gnippy/rules.py
@@ -94,13 +94,12 @@ def _delete(conf, built_rules):
             built_rules: A single or list of built rules.
     """
     _check_rules_list(built_rules)
-    rules_url = _generate_rules_url(conf['url'])
+    rules_url = _generate_rules_url(conf['url']) + "?_method=delete"
     delete_data = json.dumps(_generate_post_object(built_rules))
-    r = requests.delete(rules_url, auth=conf['auth'], data=delete_data)
+    r = requests.post(rules_url, auth=conf['auth'], data=delete_data)
     if not r.status_code in range(200,300):
         error_text = "HTTP Response Code: %s, Text: '%s'" % (str(r.status_code), r.text)
         raise RuleDeleteFailedException(error_text)
-
 
 def build(rule_string, tag=None):
     """


### PR DESCRIPTION
Quick fix to support DELETE method with POST call. 

Per the docs, "Deleting Rules with POST: This method is also available by sending a POST request to the same URL with the URL query parameter "_method=delete" (e.g. for GAE and other environments that don't allow HTTP method 'DELETE' method on HTTP requests)."

http://support.gnip.com/apis/powertrack/api_reference.html#DeleteRules
