### PR TITLE
PY3 compatibility fixes

### DIFF
--- a/gnippy/__init__.py
+++ b/gnippy/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # gnippy - GNIP for Python
+from __future__ import absolute_import
 
 __title__ = 'gnippy'
 __version__ = '0.3.4'
@@ -7,4 +8,4 @@ __author__ = 'Abhinav Ajgaonkar'
 __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright 2012-2013 Abhinav Ajgaonkar'
 
-from powertrackclient import PowerTrackClient
+from .powertrackclient import PowerTrackClient

--- a/gnippy/config.py
+++ b/gnippy/config.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 
-import ConfigParser
+try:
+    import configparser as ConfigParser
+
+except ImportError:
+    import ConfigParser
+
 import os
 
 from gnippy.errors import ConfigFileNotFoundException, IncompleteConfigurationException
@@ -20,11 +25,11 @@ def get_default_config_file_path():
     # os.path.expanduser() will fail. Attempt to detect this case and use a
     # no-op expanduser function in this case.
     try:
-      os.path.expanduser('~')
-      expanduser = os.path.expanduser
+        os.path.expanduser('~')
+        expanduser = os.path.expanduser
     except (AttributeError, ImportError):
-      # This is probably running on App Engine.
-      expanduser = (lambda x: x)
+        # This is probably running on App Engine.
+        expanduser = (lambda x: x)
     # ---End borrowed section ---------------------------------------------
     return os.path.join(expanduser("~"), ".gnippy")
 
@@ -95,8 +100,9 @@ def resolve(kwarg_dict):
             if creds['username'] and creds['password']:
                 conf['auth'] = (creds['username'], creds['password'])
             else:
-                raise IncompleteConfigurationException("Incomplete authentication information provided. Please provide"\
-                                                       + " a username and password.")
+                raise IncompleteConfigurationException(
+                    "Incomplete authentication information provided. "
+                    "Please provide a username and password.")
 
         if "url" not in conf:
             if file_conf['PowerTrack']['url']:

--- a/gnippy/powertrackclient.py
+++ b/gnippy/powertrackclient.py
@@ -58,13 +58,13 @@ class Worker(threading.Thread):
         self.url = url
         self.auth = auth
         self.on_data = callback
-        self._stop = threading.Event()
+        self._stop_event = threading.Event()
 
     def stop(self):
-        self._stop.set()
+        self._stop_event.set()
 
     def stopped(self):
-        return self._stop.isSet()
+        return self._stop_event.isSet()
 
     def run(self):
         with closing(requests.get(self.url, auth=self.auth, stream=True)) as r:

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,9 @@ try:
 except:
     license = "Apache 2.0 License"
 
+PY2 = sys.version_info < (3,)
+PY3 = not PY2
+
 setup(
     name='gnippy',
     version=version,
@@ -36,6 +39,8 @@ setup(
     url='http://pypi.python.org/pypi/gnippy/',
     license=license,
     install_requires=[
-        "requests == 1.2.0"
+        # Since this was explicitly requested for in older version, keep
+        # it as is. Use the latest requests for PY3
+        "requests == 1.2.0" if PY2 else "requests"
     ]
 )


### PR DESCRIPTION
It turned out that gnippy did not work too well with python 3.4 for example. Added import fixes, fixed inheriting from `Thread` (it has a method `_stop` now) and upgraded requests library to latest and greatest for PY3, since pypi versioning should not pull betas and devs anymore anyway.
