### PR TITLE
Resolve config should not require both url and rules_url.

### DIFF
--- a/gnippy/config.py
+++ b/gnippy/config.py
@@ -107,7 +107,7 @@ def resolve(kwarg_dict):
     elif os.getenv('GNIPPY_RULES_URL'):
         conf['rules_url'] = os.getenv("GNIPPY_RULES_URL")
 
-    if "auth" not in conf or "url" not in conf or 'rules_url' not in conf:
+    if "auth" not in conf or ("url" not in conf and 'rules_url' not in conf):
 
         if "config_file_path" in kwarg_dict:
             file_conf = get_config(config_file_path=kwarg_dict['config_file_path'])

--- a/gnippy/test/test_config.py
+++ b/gnippy/test/test_config.py
@@ -63,3 +63,31 @@ class ConfigTestCase(unittest.TestCase):
         self.assertEqual(conf['rules_url'], test_utils.test_rules_url)
         self.assertEqual(conf['auth'][0], test_utils.test_username)
         self.assertEqual(conf['auth'][1], test_utils.test_password)
+
+    def test_resolve_conf_from_kwargs1(self):
+        """ Run the "resolve" method providing kwargs and check if all info is loaded. """
+        test_utils.delete_test_config()
+        rules_url = 'http://gnip.rules.url'
+        username = 'gnip-username'
+        password = 'gnip-password'
+        conf = gnippy_config.resolve({
+            'rules_url': rules_url,
+            'auth': (username, password)
+        })
+        self.assertEqual(conf['rules_url'], rules_url)
+        self.assertEqual(conf['auth'][0], username)
+        self.assertEqual(conf['auth'][1], password)
+
+    def test_resolve_conf_from_kwargs2(self):
+        """ Run the "resolve" method providing kwargs and check if all info is loaded. """
+        test_utils.delete_test_config()
+        url = 'http://gnip.url'
+        username = 'gnip-username'
+        password = 'gnip-password'
+        conf = gnippy_config.resolve({
+            'url': url,
+            'auth': (username, password)
+        })
+        self.assertEqual(conf['url'], url)
+        self.assertEqual(conf['auth'][0], username)
+        self.assertEqual(conf['auth'][1], password)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import os
 import sys
 
-version = "0.6.0"
+version = "0.6.1"
 
 try:
     from setuptools import setup


### PR DESCRIPTION
Missed this before. Going to need help to deploy to PyPI.
