### PR TITLE
PowerTrackClient Connection Status

### DIFF
--- a/gnippy/powertrackclient.py
+++ b/gnippy/powertrackclient.py
@@ -9,7 +9,7 @@ import requests
 from gnippy import config
 
 
-class PowerTrackClient():
+class PowerTrackClient:
     """
         PowerTrackClient allows you to connect to the GNIP
         power track stream and fetch data.
@@ -32,6 +32,7 @@ class PowerTrackClient():
         self.worker.start()
 
     def connected(self):
+
         return not self.worker.stopped()
 
     def disconnect(self):

--- a/gnippy/powertrackclient.py
+++ b/gnippy/powertrackclient.py
@@ -31,6 +31,9 @@ class PowerTrackClient():
         self.worker.setDaemon(True)
         self.worker.start()
 
+    def connected(self):
+        return not self.worker.stopped()
+
     def disconnect(self):
         self.worker.stop()
         self.worker.join()
@@ -90,3 +93,7 @@ class Worker(threading.Thread):
             else:
                 # re-raise the last exception as-is
                 raise
+        finally:
+            if not self.stopped():
+                # clean up and set the stop event
+                self.stop()

--- a/gnippy/test/test_powertrackclient.py
+++ b/gnippy/test/test_powertrackclient.py
@@ -155,8 +155,6 @@ class PowerTrackClientTestCase(unittest.TestCase):
 
         self.assertFalse(client.connected())
 
-        client.disconnect()
-
     @mock.patch('requests.get', get_request_stream)
     def test_connected_status_true_when_running(self):
         """ Once the client connect method is called the client reports as connected. """


### PR DESCRIPTION
This allows the process that started to the PowerTrackClient to be able to see if the client is actually connected , we use it to push metrics so we can know if/when one of the clients on redundant streams stops for any reason.
