### PR TITLE
Added option to specify backfill minutes on the connect call

### DIFF
--- a/gnippy/test/test_powertrackclient.py
+++ b/gnippy/test/test_powertrackclient.py
@@ -5,10 +5,8 @@ from time import sleep
 
 import mock
 
-<<<<<<< 5aad86859b37e17aa6cd8c972150886fdc989cbb
-=======
+from gnippy.powertrackclient import append_backfill_to_url
 
->>>>>>> added option to specify backfill minutes on the connect call
 try:
     import unittest2 as unittest
 except ImportError:
@@ -222,3 +220,24 @@ class PowerTrackClientTestCase(unittest.TestCase):
         client = PowerTrackClient(_dummy_callback, config_file_path=config_file)
 
         self.assertRaises(AssertionError, client.connect, backfill_minutes)
+
+    def test_append_backfill_to_url_appends_backfillMinutes_param(self):
+
+        base_url = "http://www.twitter.com"
+        backfill_minutes = 2
+        expected_url = "http://www.twitter.com?backfillMinutes=2"
+
+        returned_value = append_backfill_to_url(base_url, backfill_minutes)
+
+        self.assertEqual(returned_value, expected_url)
+
+    def test_append_backfill_to_url_replaces_existing_backfillMinutes_param(
+            self):
+
+        base_url = "http://www.twitter.com?backfillMinutes=5"
+        backfill_minutes = 1
+        expected_url = "http://www.twitter.com?backfillMinutes=1"
+
+        returned_value = append_backfill_to_url(base_url, backfill_minutes)
+
+        self.assertEqual(returned_value, expected_url)

--- a/gnippy/test/test_powertrackclient.py
+++ b/gnippy/test/test_powertrackclient.py
@@ -5,6 +5,10 @@ from time import sleep
 
 import mock
 
+<<<<<<< 5aad86859b37e17aa6cd8c972150886fdc989cbb
+=======
+
+>>>>>>> added option to specify backfill minutes on the connect call
 try:
     import unittest2 as unittest
 except ImportError:
@@ -136,6 +140,7 @@ class PowerTrackClientTestCase(unittest.TestCase):
                                   config_file_path=config_file)
         client.connect()
         client.disconnect()
+
         self.assertTrue(exception_callback.called)
         actual_exinfo = exception_callback.call_args[0][0]
         actual_ex = actual_exinfo[1]
@@ -170,3 +175,50 @@ class PowerTrackClientTestCase(unittest.TestCase):
         client.disconnect()
 
         self.assertFalse(client.connected())
+
+    @mock.patch('requests.get')
+    def test_backfill_value_appended_to_url(self, mocked_requests_get):
+        """When passing a backfill value it is appended to the url call to
+        GNIP"""
+
+        backfill_minutes = 3
+
+        expected_powertrack_url = "{0}?backfillMinutes={1}".format(
+            test_utils.test_powertrack_url, backfill_minutes)
+
+        test_utils.generate_test_config_file()
+
+        client = PowerTrackClient(_dummy_callback, config_file_path=config_file)
+
+        client.connect(backfill_minutes=backfill_minutes)
+        client.disconnect()
+
+        mocked_requests_get.assert_called_with(
+            expected_powertrack_url,
+            auth=(test_utils.test_username, test_utils.test_password),
+            stream=True
+        )
+
+    def test_non_integer_backfill_value_raises_exception(self):
+        """When passing a backfill value that isn't an integer raises an
+        exception"""
+
+        backfill_minutes = "FOUR"
+
+        test_utils.generate_test_config_file()
+
+        client = PowerTrackClient(_dummy_callback, config_file_path=config_file)
+
+        self.assertRaises(AssertionError, client.connect, backfill_minutes)
+
+    def test_backfill_value_greater_than_five_raises_exception(self):
+        """When passing a backfill value that isn't an integer raises an
+        exception"""
+
+        backfill_minutes = 12
+
+        test_utils.generate_test_config_file()
+
+        client = PowerTrackClient(_dummy_callback, config_file_path=config_file)
+
+        self.assertRaises(AssertionError, client.connect, backfill_minutes)


### PR DESCRIPTION
Added optional backfill minutes value as per the GNIP 2.0 [documentation](http://support.gnip.com/apis/powertrack2.0/recovery.html#backfill-a-idbackfill-classtallnbspa) 
