### PR TITLE
Gnip now returns id_str field for each rule.

### DIFF
--- a/gnippy/rules.py
+++ b/gnippy/rules.py
@@ -31,7 +31,7 @@ def _check_rules_list(rules_list):
     if not isinstance(rules_list, list):
         fail()
 
-    expected = ("value", "tag", "id")
+    expected = ("value", "tag", "id", "id_str")
     for r in rules_list:
         if not isinstance(r, dict):
             fail()


### PR DESCRIPTION
Before, it was possible to retrieve rules from GNIP, and use the same list of rules for deletion. Now, GNIP added a new field `id_str` to rules it returns, and gnippy fails in `_check_rules_list` because it does not expect this field.

Note: GNIP actually ignores `id` and `id_str` *when adding rules*, but it does not fail if those are present. So it is possible to retrieve rules from GNIP and then use them as-is in `method=add` request. Gnippy should allow it too.