### PR TITLE
Loosen six pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
     license=license,
     install_requires=[
         "requests>=2.8.1,<3.0.0",
-        "six==1.10.0"
+        "six>=1.10.0"
     ]
 )


### PR DESCRIPTION
Libraries should not pin their dependencies to exact versions, as it will inevitably lead to version conflicts.